### PR TITLE
Fix the CheckESPTimeout and its constant, remove WaitRaster, add init empty Rx FIFO

### DIFF
--- a/src/constants.inc.asm
+++ b/src/constants.inc.asm
@@ -22,7 +22,9 @@ CPUSpeed              		equ $07
 VARS                    	EQU $5c4b		; addr of variables area
 NEXT_ONE_r3             	EQU $19b8           	; find next variable
 
-ESPTimeout              	EQU 65535*4;65535 	; Use 10000 for 3.5MHz, but 28NHz needs to be 65535
+ESPTimeoutInSeconds       	EQU 60 ; Seconds, use this one to adjust timeout
+                        	; ESPTimeoutI is an 64-bit const which fits CheckESPTimeout
+ESPTimeoutI              	EQU 65535 + ((22*ESPTimeoutInSeconds/10)<<16) ; formula for 28MHz
 
 BORDCR				EQU 23624
 

--- a/src/esp-timeout.asm
+++ b/src/esp-timeout.asm
@@ -1,9 +1,9 @@
 InitESPTimeout:
 	MODULE InitESPTimeout
 		push hl
-		ld hl, ESPTimeout mod 65536 	; Timeout is a 32-bit value, so save the two LSBs first,
+		ld hl, ESPTimeoutI mod 65536 	; Timeout is a 32-bit value, so save the two LSBs first,
 		ld (CheckESPTimeout.Value), hl
-		ld hl, ESPTimeout / 65536	; then the two MSBs.
+		ld hl, ESPTimeoutI / 65536	; then the two MSBs.
 		ld (CheckESPTimeout.Value2), hl
 		pop hl
 		ret
@@ -18,7 +18,6 @@ Value 	EQU $+1
 		ld hl, SMC
 		dec hl
 		ld (Value), hl
-		call WaitRaster
 		ld a, h
 		or l
 		jr z, Rollover
@@ -36,26 +35,9 @@ Value2 	EQU $+1
 		or l
 		jr z, Failure			; If we hit here, 32 bit value is $00000000
 		dec hl
-		call WaitRaster
 		ld (Value2), hl
-		ld hl, ESPTimeout mod 65536
+		ld hl, ESPTimeoutI mod 65536
 		ld (Value), hl
 		jr Success
-
-// https://github.com/remy/next-http/issues/7
-WaitRaster:
-		push bc
-		push af
-.waitloop:
-		ld bc, $243b
-		ld a, $1f     			; only really care about lsb
-		out (c), a
-		inc b
-		in a, (c)
-		cp 192
-		jr nz, .waitloop
-		pop af
-		pop bc
-		ret
 
 	ENDMODULE

--- a/src/uart.asm
+++ b/src/uart.asm
@@ -48,7 +48,15 @@ SMC_skip_baud_init
 		rla				; Now in Bit 0
 		or %10000000			; Set MSB to req. write to upper 7 bits
 		out (c), a
-		ret
+		; stale data taken out from FIFO at max speed
+.staleFIFOclean
+		ld bc, UART_GetStatus
+		in a, (c)
+		rra
+		ret nc
+		ld bc, UART_RxD
+		in a, (c)
+		jr .staleFIFOclean
 
 .baudTable:
 		DEFW 243,248,256,260,269,278,286,234	; 115K
@@ -106,7 +114,6 @@ write:
 	IFDEF TESTING
 		call debug
 	ENDIF
-
 		ld bc, UART_GetStatus
 .wait
 		in a, (c)


### PR DESCRIPTION
As each WaitRaster causes up to a whole frame busy wait, the constant used for timeout produced a practically infinite wait in 1.1.0. Here WaitRaster is removed from CheckESPTimeout , and instead the constant calculation adjusted to specify the timeout in seconds. As many seconds are needed for slow requests over the internet, a timeout constant of 60 seconds (in 28MHz mode) is specified to also comply with the reason which lead to the introduction of WaitRaster.
Also an UART init is adjusted to perform fast emptying of Rx FIFO at the start.